### PR TITLE
Modifié trainH.html

### DIFF
--- a/lines/trainH.html
+++ b/lines/trainH.html
@@ -12,7 +12,7 @@
 <body>
 	<a href="/parismetro"><h1 class="header">MobiFer</h1></a>
 	<p class="centered"><strong>Transilien</strong><br>
-	<span style="font-size: 80px;"><span class="integrated"><img src="/parismetro/assets/icons/symbole_Transilien_RVB.svg" alt="Transilien"></span>&thinsp;<span class="integrated"><img src="/parismetro/assets/icons/Transilien_H_couleur_RVB.svg" alt="H"></span></span><br>
+	<span style="font-size: 80px;"><span class="integrated"><img src="/parismetro/assets/icons/symbole_train_RVB.svg" alt="Transilien"></span>&thinsp;<span class="integrated"><img src="/parismetro/assets/icons/train_H_couleur_RVB.svg" alt="H"></span></span><br>
 	<span class="centered" style="font-size: 30px;"><strong>Paris – Nord <span class="integrated"><img src="/parismetro/assets/text/double_fleche.svg" alt="Double flèche"></span> Pontoise • Creil • Luzarches </strong></span></p>
 	<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Francilien_Transilien_H_en_gare_d%27Epinay-Villetaneuse.jpg/1024px-Francilien_Transilien_H_en_gare_d%27Epinay-Villetaneuse.jpg" alt="Illustration de la ligne" style="width: 100%; max-width: 800px; border-radius: 10px;" class="image-center">
 	<div class="license">© Remontees sur <a href="https://commons.wikimedia.org/wiki/File:Francilien_Transilien_H_en_gare_d%27Epinay-Villetaneuse.jpg">Wikimedia Commons</a></div>
@@ -38,7 +38,7 @@
 			</tr>
 			<tr>
 				<td class="title">Matériel</td>
-				<td>Francilien (Z 50000)(102 éléments au 29/06/2022,matériel en exploitation commune avec la ligne K)</td>
+				<td>Francilien (Z 50000) (102 éléments au 29/06/2022, matériel en exploitation commune avec la ligne K)</td>
 			</tr>
 			<tr>
 				<td class="title">Conduite<br>(système)</td>


### PR DESCRIPTION
Correction d'erreurs ;
- Erreur dans l'adresse de deux icônes ;
- Manque d'espaces.